### PR TITLE
Refactor model path in OCR examples to a relative path for easier access

### DIFF
--- a/tutorials/ocr_example/ocr_polygon_example.py
+++ b/tutorials/ocr_example/ocr_polygon_example.py
@@ -14,7 +14,7 @@ from rex_omni import RexOmniVisualize, RexOmniWrapper
 
 def main():
     # Model path - replace with your actual model path
-    model_path = "/comp_robot/jiangqing/projects/2023/research/R1/QwenSFTOfficial/open_source/IDEA-Research/Rex-Omni"
+    model_path = "IDEA-Research/Rex-Omni"
 
     print("🚀 Initializing Rex Omni model...")
 

--- a/tutorials/ocr_example/ocr_textline_box_example.py
+++ b/tutorials/ocr_example/ocr_textline_box_example.py
@@ -14,7 +14,7 @@ from rex_omni import RexOmniVisualize, RexOmniWrapper
 
 def main():
     # Model path - replace with your actual model path
-    model_path = "/comp_robot/jiangqing/projects/2023/research/R1/QwenSFTOfficial/open_source/IDEA-Research/Rex-Omni"
+    model_path = "IDEA-Research/Rex-Omni"
 
     print("🚀 Initializing Rex Omni model...")
 

--- a/tutorials/ocr_example/ocr_word_box_example.py
+++ b/tutorials/ocr_example/ocr_word_box_example.py
@@ -14,7 +14,7 @@ from rex_omni import RexOmniVisualize, RexOmniWrapper
 
 def main():
     # Model path - replace with your actual model path
-    model_path = "/comp_robot/jiangqing/projects/2023/research/R1/QwenSFTOfficial/open_source/IDEA-Research/Rex-Omni"
+    model_path = "IDEA-Research/Rex-Omni"
 
     print("🚀 Initializing Rex Omni model...")
 


### PR DESCRIPTION
## Refactor model path in OCR examples to a relative path for easier access

### Summary
Refactors model paths in OCR example scripts to use a relative HuggingFace model identifier instead of absolute paths, improving portability and ease of use.

### Changes
- Updated model path in three OCR example files:
  - `tutorials/ocr_example/ocr_polygon_example.py`
  - `tutorials/ocr_example/ocr_textline_box_example.py`
  - `tutorials/ocr_example/ocr_word_box_example.py`

### Details
Changed the model path from an absolute file path to the HuggingFace model identifier `"IDEA-Research/Rex-Omni"`, allowing the examples to work without hardcoded paths and automatically download the model when needed.

### Benefits
- Improved portability: examples work across different environments
- Easier setup: no need to configure absolute paths
- Better user experience: model downloads automatically from HuggingFace
- Consistency: aligns with standard HuggingFace model loading practices

### Testing
- [v] Verified all three OCR examples run successfully with the new model path
- [v] Confirmed model downloads correctly from HuggingFace when needed
